### PR TITLE
Add mutations (children and swaps)

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -64,7 +64,7 @@ function plot_fitness_history(
     for i in 1:size(transition_counts_matrix, 2)
         lines!(a_type, transition_counts_matrix[:,i], label=string(transition_counts_keys[i]))
     end
-    axislegend(a_type, position=:rb)
+    axislegend(a_type, position=:rb,labelsize=10,patchsize=(10,10))
 
     return fig
 end

--- a/src/evolve.jl
+++ b/src/evolve.jl
@@ -77,6 +77,7 @@ function add_mutations!(
     p_mutate=0.1,
     p_gain=0.1,
     p_child=0.1,
+    p_swap=0.1
 )
     mutants = Individual[]
 
@@ -90,12 +91,14 @@ function add_mutations!(
             # swap_op::Bool   = TODO
             _mutate::Bool = rand() < p_mutate && l > 0
             _child::Bool = rand() < p_child && l > 0 
+            _swap_op::Bool = rand() < p_swap && l > 1
 
             _drop_op && push!(mutants, drop_op(indiv))
             _gain_op && push!(mutants, gain_op(indiv; valid_pairs))
             _mutate && push!(mutants, mutate(indiv))
              # parents will be this indiv, and a random other one
             _child && push!(mutants, make_child(indiv.ops, rand(individuals).ops,max_ops)) 
+            _swap_op && push!(mutants,swap_op(indiv.ops))
 
         end
     end

--- a/src/evolve.jl
+++ b/src/evolve.jl
@@ -76,6 +76,7 @@ function add_mutations!(
     p_drop=0.1,
     p_mutate=0.1,
     p_gain=0.1,
+    p_child=0.1,
 )
     mutants = Individual[]
 
@@ -88,10 +89,14 @@ function add_mutations!(
             _gain_op::Bool   = rand() < p_gain   && l < max_ops
             # swap_op::Bool   = TODO
             _mutate::Bool = rand() < p_mutate && l > 0
+            _child::Bool = rand() < p_child && l > 0 
 
             _drop_op && push!(mutants, drop_op(indiv))
             _gain_op && push!(mutants, gain_op(indiv; valid_pairs))
             _mutate && push!(mutants, mutate(indiv))
+             # parents will be this indiv, and a random other one
+            _child && push!(mutants, make_child(indiv.ops, rand(individuals).ops,max_ops)) 
+
         end
     end
 

--- a/src/mutate.jl
+++ b/src/mutate.jl
@@ -68,3 +68,17 @@ function rand_op(valid_pairs)
     end
     return op
 end
+
+function make_child(mother_ops::Vector{Any}, father_ops::Vector{Any},max_ops::Int64)
+    # Child algorithm:
+    # choose a location to 'split' the circuits of both the mother and father. The mother and father have their own splits. All ops up to the split will be taken from the mother, and all ops from the end-minus-split to the end will be taken from the father. 
+
+    # to make sure that we do not pass the max ops limit, the max split will be half of the max ops. This is because the amount of ops in the end will be mother_split + father_split
+    mother_split = rand(1:min(convert(Int,floor(max_ops/2)),length(mother_ops)))
+    father_split = rand(1:min(convert(Int,floor(max_ops/2)),length(father_ops)))
+    
+    # mark the history, and concat the ops
+    child = Individual(:child,[mother_ops[1:mother_split]; father_ops[end-father_split+1:end]])
+    @assert (mother_split + father_split) == length(child.ops)
+    return child
+end

--- a/src/mutate.jl
+++ b/src/mutate.jl
@@ -69,6 +69,7 @@ function rand_op(valid_pairs)
     return op
 end
 
+"make a 'child' indivdual from meshing together two individuals' operations"
 function make_child(mother_ops::Vector{Any}, father_ops::Vector{Any},max_ops::Int64)
     # Child algorithm:
     # choose a location to 'split' the circuits of both the mother and father. The mother and father have their own splits. All ops up to the split will be taken from the mother, and all ops from the end-minus-split to the end will be taken from the father. 
@@ -81,4 +82,20 @@ function make_child(mother_ops::Vector{Any}, father_ops::Vector{Any},max_ops::In
     child = Individual(:child,[mother_ops[1:mother_split]; father_ops[end-father_split+1:end]])
     @assert (mother_split + father_split) == length(child.ops)
     return child
+end
+
+"make a new individual with two operations randomly swapped"
+function swap_op(ops::Vector{Any})
+    @assert length(ops) >= 2 
+
+    # select locations
+    l = length(ops)
+    i = rand(1:l)
+    j = i 
+    while (j==i) j = rand(1:l); end # select until i != j  
+
+    # swap the ops
+    new_ops = deepcopy(ops) 
+    new_ops[j],new_ops[i] = new_ops[i],new_ops[j]
+    return Individual(:swap,new_ops)
 end


### PR DESCRIPTION
closes #7 

Changes:
1. Adds child mutations. This will take the first few ops from one individual, and the last few from the other. The maximum amount of ops of the child will be the max_ops config.
2. Adds swap mutations. Swaps a random op with another in the same individual. 
3. Small tweak to plots axis legend size to fit the new types.

Very little change to total output of the optimizer.