### PR TITLE
Performance calculations carry over from previous runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.1.1 - 2025-07-29
+- Performance evaluations carry over from previous runs. 
+- Warning when simulation is throttled (fidelity = 1)
+
 ## v0.1.0 - 2025-06-13
 
 - Simulation capabilities for commond gates.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QEPOptimize"
 uuid = "9f67e06f-6394-43be-a72d-a2000081c01d"
 authors = ["Stefan Krastanov <stefan@krastanov.org>", "QEPOptimize contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 BPGates = "2c1a90cd-bec4-4415-ae35-245016909a8f"

--- a/example/pluto.jl
+++ b/example/pluto.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.10
+# v0.20.13
 
 using Markdown
 using InteractiveUtils
@@ -64,6 +64,8 @@ md"""
 
 * Number of Simulations: $(@bind num_simulations PlutoUI.Slider(100:100:5000, default=1000, show_value=true))
 
+* Max performance calculations per circuit: $(@bind max_perf_calcs PlutoUI.Slider(1:1:50, default=10, show_value=true))
+
 * Population Size: $(@bind pop_size PlutoUI.Slider(10:10:100, default=20, show_value=true))
 
 * Initial Operations: $(@bind start_ops PlutoUI.Slider(5:20, default=10, show_value=true))
@@ -73,7 +75,7 @@ md"""
 
 * Number of Evolution Steps: $(@bind evolution_steps PlutoUI.Slider(50:150, default=80, show_value=true))
 
-* New Mutants: $(@bind new_mutants PlutoUI.Slider(5:5:30, default=10, show_value=true))
+* New Mutants: $(@bind new_mutants PlutoUI.Slider(5:1:30, default=10, show_value=true))
 
 * Drop Probability: $(@bind p_drop PlutoUI.Slider(0.0:0.05:0.5, default=0.1, show_value=true))
 
@@ -92,6 +94,7 @@ begin
 	    code_distance=1, # Not needed to change for now
 	    pop_size=pop_size,
 	    noises=[NetworkFidelity(network_fidelity), PauliNoise(paulix, pauliy, pauliz)],
+		max_performance_calcs=max_perf_calcs
 	)
 	
 	init_config = (;

--- a/src/QEPOptimize.jl
+++ b/src/QEPOptimize.jl
@@ -1,5 +1,7 @@
 module QEPOptimize
 
+import Base:+,==
+
 using BPGates
 using BPGates: mctrajectory!, continue_stat, PauliNoise # TODO these should be exported by default
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,8 @@
 # TODO (low priority) this would be a great place to use an Enum or, even better, an algebraic data type (ADT)
 const HISTORIES = [:manual, :survivor, :random, :child, :drop, :gain, :swap, :opsmutate]
 
+const THROTTLE_WARNINGS = 10 # max amount of warnings per multiple_steps_with_history! call
+
 "A convenient structure to store various purification performance metrics."
 struct Performance
     "a list of probabilities as such `[probability for no errors, probability for one Bell pair to be erroneous, probability for two Bell pairs to be erroneous, ..., probability for all Bell pairs to be erroneous]`"
@@ -15,12 +17,62 @@ struct Performance
     average_marginal_fidelity::Float64
     "the proportion of runs of a given protocol that do not have detected errors (i.e. Alice and Bob do not measure any errors)"
     success_probability::Float64
+    "the number of times that performance has been calculated and averaged for this circuit"
+    num_calcs::Int64
 end
 
-Performance() = Performance(Float64[], 0.0, 0.0, 0.0, 0.0)
+Performance() = Performance(Float64[], 0.0, 0.0, 0.0, 0.0,0)
 
-Base.copy(p::Performance) = Performance(copy(p.error_probabilities), p.purified_pairs_fidelity, p.logical_qubit_fidelity, p.average_marginal_fidelity, p.success_probability)
+Base.copy(p::Performance) = Performance(copy(p.error_probabilities), p.purified_pairs_fidelity, p.logical_qubit_fidelity, p.average_marginal_fidelity, p.success_probability,p.num_calcs)
 
+"""
+    +(a::Performance,b::Performance)
+
+Add two performance points, and average them.
+"""
+function +(a::Performance,b::Performance) 
+    # start with using a's
+    new_error_probabilities = a.error_probabilities
+
+    # if error probs are empty on a, use b. if b is also empty, dosen't matter, both are empty, use a.
+    if isempty(a.error_probabilities)
+        new_error_probabilities =  b.error_probabilities
+    elseif !isempty(b.error_probabilities)
+        # make sure error probs are same shape
+        if length(a.error_probabilities) != length(b.error_probabilities)
+            @warn "Error probabilities mismatch, defaulting to new performance"
+            # differing error_prob lengths should have been dealt with. This warning is only reached if there is a bug in the circuit performance calculator
+            return b
+        else 
+            # both error probs are nonempty, and same length. Sum and divide them 
+            for i in 1:length(a.error_probabilities)
+                new_error_probabilities[i] = (a.error_probabilities[i] + b.error_probabilities[i]) / 2
+            end
+        end
+    end
+
+    # Now average the rest of the attributes (floats)
+    new_purified_pairs_fidelity = (a.purified_pairs_fidelity + b.purified_pairs_fidelity) / 2
+    new_logical_qubit_fidelity = (a.logical_qubit_fidelity + b.logical_qubit_fidelity) / 2
+    new_average_marginal_fidelity = (a.average_marginal_fidelity + b.average_marginal_fidelity) / 2
+    new_success_probability = (a.success_probability + b.success_probability) / 2
+
+    # and mark that new calcs were added
+    new_num_calcs = a.num_calcs + b.num_calcs
+    return Performance(new_error_probabilities,new_purified_pairs_fidelity ,new_logical_qubit_fidelity,new_average_marginal_fidelity,new_success_probability,new_num_calcs)
+end
+
+"""
+    ==(a::Performance, b::Performance)
+
+Compare equality of all internal values of a performance stuct. Used for testing.
+"""
+==(a::Performance, b::Performance) = (a.error_probabilities == b.error_probabilities &&
+                                    a.purified_pairs_fidelity == b.purified_pairs_fidelity &&
+                                    a.logical_qubit_fidelity == b.logical_qubit_fidelity &&
+                                    a.average_marginal_fidelity == b.average_marginal_fidelity &&
+                                    a.success_probability == b.success_probability && 
+                                    a.num_calcs == b.num_calcs)
 
 "An individual (circuit) in the population we are evolving"
 mutable struct Individual

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -1,0 +1,18 @@
+using TestItems
+
+@testitem "performance averaging" begin
+    using QEPOptimize
+    using QEPOptimize:Performance
+
+    low = Performance([0,0,1],0,0,0,0,1)
+    high = Performance([1,0,0],1,1,1,1,1)
+    mid = low + high
+    @test mid == Performance([0.5,0,0.5],0.5,0.5,0.5,0.5,2)
+
+    # works with +=
+    low = Performance([0,0,1],0,0,0,0,1)
+    high = Performance([1,0,0],1,1,1,1,1)
+
+    low += high
+    @test low == mid
+end


### PR DESCRIPTION
- **Performance evaluations carry over from previous. Warn user when sim is throttled. Small test added**
- Averages over the last 10 performance calculations by default. Added a paremeter to set this value 'max performance calcs'
- If after the max performance calcs, the peformance is still 1.0, additional performance calculations will be done, and this case also triggers a warning to the user.
- If the user changes certain parameters, such as the amount of purified pairs, the previous performances will be discarded.
 
- **v0.1.1, update changelog**

