### PR TITLE
Add Documenter docs alongside Pluto export

### DIFF
--- a/.github/workflows/ExportPluto.yaml
+++ b/.github/workflows/ExportPluto.yaml
@@ -5,10 +5,11 @@ on:
             - master
     workflow_dispatch:
 
-# When two jobs run in parallel, cancel the older ones, to make sure that the website is generated from the most recent commit.
+# Serialize all writers to gh-pages so Pluto exports and Documenter deployments
+# cannot overwrite each other.
 concurrency:
-    group: pluto-export
-    cancel-in-progress: true
+    group: qepoptimize-gh-pages
+    cancel-in-progress: false
 
 # This action needs permission to write the exported HTML file to the gh-pages branch.
 permissions:
@@ -67,5 +68,7 @@ jobs:
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   branch: gh-pages
-                  folder: .
-                  single-commit: true
+                  folder: example
+                  target-folder: example
+                  clean: false
+                  force: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    concurrency:
+      group: qepoptimize-gh-pages
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+QEPOptimize = "9f67e06f-6394-43be-a72d-a2000081c01d"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,18 @@
+using Documenter
+using QEPOptimize
+
+makedocs(
+    sitename = "QEPOptimize.jl",
+    modules = [QEPOptimize],
+    doctest = false,
+    warnonly = :missing_docs,
+    pages = [
+        "Home" => "index.md",
+    ],
+)
+
+deploydocs(
+    repo = "github.com/QuantumSavory/QEPOptimize.jl.git",
+    devbranch = "master",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,7 @@
+# QEPOptimize.jl
+
+See the demo at [doc.quantumsavory.org/QEPOptimize.jl/example/pluto.html](https://doc.quantumsavory.org/QEPOptimize.jl/example/pluto.html)
+
+A framework for optimization of entanglement purification circuits based on the [BPGates.jl simulator](https://github.com/QuantumSavory/BPGates.jl/), following methods published in ["Optimized Entanglement Purification"](https://quantum-journal.org/papers/q-2019-02-18-123/) and ["Faster-than-Clifford simulations of entanglement purification circuits and their full-stack optimization"](https://www.nature.com/articles/s41534-024-00948-0).
+
+The examples folder contains a Pluto notebook with a user-friendly UI for generating optimized entanglement distillation circuits and lists how the public API of this library is to be used.


### PR DESCRIPTION
Adds a minimal README-backed Documenter site with pull-request previews and the correct GitHub deployment target.

The existing Pluto export now publishes only `example/` into the matching `gh-pages` subdirectory, while a shared non-cancelling concurrency group serializes both `gh-pages` writers. This preserves `/example/pluto.html` and lets Documenter own the normal root/version/preview paths without force-replacing branch history.

Validation:
- instantiated the docs environment with the package developed locally
- built `docs/make.jl` successfully (only expected missing-docstring warnings)
- parsed both modified workflows as YAML
- `git diff --check`